### PR TITLE
Add SemVer match support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ structopt = "0.3.21"
 toml_edit = "0.2.0"
 reqwest = { version = "0.11.2", features = ["blocking", "gzip"] }
 serde_json = "1.0.64"
+semver = "0.11.0"
 
 [lib]
 name = "libdr"

--- a/README.md
+++ b/README.md
@@ -4,26 +4,57 @@ dependency-refresh is meant to update rust dependency versions within Cargo.toml
 
 The tool reads the given toml files and checks online at https://crates.io for the latest version of each dependency.
 
+By default dependency-refresh compares the versions according to Semantic versioning (see https://semver.org/) rules. Therefore, dependency-refresh does not update the version in the local Cargo.toml, if the new crates.io version is a compatible minor update. This behavior usually is desired, because Cargo uses the latest compatible version anyway. To override this, pass the option --exact to dependency-refresh. That will disable Semantic versioning compare and will always trigger an update of the local version.
+
 I am aware that there is room for improvement in my rust code, so feel free to comment or submit small patches.
 
-## Example usage
+## Example usage with SemVer (default)
 
 ```sh
-$ ./dr /home/jm/IdeaProjects/dependency-refresh/Cargo.toml
-Reading file: /home/jm/IdeaProjects/dependency-refresh/Cargo.toml
+$ ./target/debug/dr ./Cargo.toml
+Reading file: ./Cargo.toml
         Found: structopt
-                Local version:  0.2
-                Online version: 0.2.15
+                Local version:  0.3.0
+                Online version: 0.3.21
         Found: toml_edit
-                Local version:  0.1.3
-                Online version: 0.1.3
+                Local version:  0.2.0
+                Online version: 0.2.0
         Found: reqwest
-                Local version:  0.9.13
-                Online version: 0.9.13
+                Local version:  0.11.0
+                Online version: 0.11.2
         Found: serde_json
-                Local version:  1.0
-                Online version: 1.0.39
-$
+                Local version:  1.0.0
+                Online version: 1.0.64
+        Found: semver
+                Local version:  0.10.0
+                Online version: 0.11.0
+        Updating: semver 0.10.0 => 0.11.0
+```
+
+## Example usage with exact matching (no SemVer)
+
+```sh
+$ ./target/debug/dr --exact ./Cargo.toml
+Reading file: ./Cargo.toml
+        Found: structopt
+                Local version:  0.3.0
+                Online version: 0.3.21
+        Found: toml_edit
+                Local version:  0.2.0
+                Online version: 0.2.0
+        Found: reqwest
+                Local version:  0.11.0
+                Online version: 0.11.2
+        Found: serde_json
+                Local version:  1.0.0
+                Online version: 1.0.64
+        Found: semver
+                Local version:  0.10.0
+                Online version: 0.11.0
+        Updating: structopt 0.3.0 => 0.3.21
+        Updating: serde_json 1.0.0 => 1.0.64
+        Updating: semver 0.10.0 => 0.11.0
+        Updating: reqwest 0.11.0 => 0.11.2
 ```
 
 ## Installation

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -16,13 +16,21 @@ struct Opt {
 
     #[structopt(short = "u", long = "unsafe-file-updates")]
     unsafe_file_updates: bool,
+
+    /// Use exact version compare instead of SemVer compare for version comparison.
+    /// If this option is given, then even minor version updates will
+    /// be recognized as new versions.
+    /// Usually exact compare is not needed, because Cargo recognizes compatible SemVer
+    /// versions and uses the latest compatible version anyway.
+    #[structopt(short, long)]
+    exact: bool,
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
     let opt = Opt::from_args();
 
     for file in &opt.toml_files {
-        libdr::update_toml_file(file, opt.unsafe_file_updates)?;
+        libdr::update_toml_file(file, opt.unsafe_file_updates, !opt.exact)?;
     }
 
     Ok(())


### PR DESCRIPTION
In my Cargo.toml files I tend to specify the base version of the SemVer compatible versions.
e.g. if there is foo 0.5.42 I specify the dependency foo = "0.5"
Cargo will then take care of fetching the latest compatible version according to SemVer rules.

This change adds SemVer comparison support.
If the option is enabled, then versions in Cargo.toml will not be updated, if the online version is compatible and Cargo would fetch the latest version anyway.

What do you think?
Does this make sense?
Should we even enable it by default?

If you agree with this change, I will do a couple of cleanups (e.g. remove the new unwraps, add some text to the Readme) before you may pull this.

Thanks :)