### PR TITLE
Avoid updating to yanked versions and pre-releases by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ structopt = "0.3.21"
 toml_edit = "0.2.0"
 reqwest = { version = "0.11.2", features = ["blocking", "gzip"] }
 serde_json = "1.0.64"
-semver = "0.11.0"
+semver = "1.0.0"
 
 [lib]
 name = "libdr"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -24,13 +24,25 @@ struct Opt {
     /// versions and uses the latest compatible version anyway.
     #[structopt(short, long)]
     exact: bool,
+
+    /// Allow update to yanked versions.
+    #[structopt(short, long)]
+    yanked: bool,
+
+    /// Allow update to pre-release (-beta or -rc) versions.
+    #[structopt(short, long)]
+    pre_release: bool,
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
     let opt = Opt::from_args();
 
     for file in &opt.toml_files {
-        libdr::update_toml_file(file, opt.unsafe_file_updates, !opt.exact)?;
+        libdr::update_toml_file(file,
+                                opt.unsafe_file_updates,
+                                !opt.exact,
+                                opt.yanked,
+                                opt.pre_release)?;
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,18 @@ impl std::fmt::Display for Error {
     }
 }
 
+struct DepRefresh {
+    use_semver:         bool,
+    allow_yanked:       bool,
+    allow_prerelease:   bool,
+}
+
 pub fn update_toml_file(
     filename: &str,
     unsafe_file_updates: bool,
     use_semver: bool,
+    allow_yanked: bool,
+    allow_prerelease: bool,
 ) -> Result<(), Box<dyn error::Error>> {
     println!("Reading file: {}", filename);
 
@@ -41,7 +49,12 @@ pub fn update_toml_file(
             .expect("Something went wrong reading the file.");
     }
 
-    let new_contents = update_toml(&contents, use_semver)?;
+    let dr = DepRefresh {
+        use_semver,
+        allow_yanked,
+        allow_prerelease,
+    };
+    let new_contents = dr.update_toml(&contents)?;
     if new_contents == contents {
         return Ok(());
     }
@@ -88,7 +101,12 @@ version = "0.2.1"
 autocfg = "1.0.0"
     "#;
 
-    let result = update_toml(toml, true).unwrap();
+    let dr = DepRefresh {
+        use_semver:         true,
+        allow_yanked:       false,
+        allow_prerelease:   false,
+    };
+    let result = dr.update_toml(toml).unwrap();
     assert_eq!(result, expected);
 }
 
@@ -124,139 +142,182 @@ version = "0.2.1"
 autocfg = "1.0.1"
     "#;
 
-    let result = update_toml(toml, false).unwrap();
+    let dr = DepRefresh {
+        use_semver:         false,
+        allow_yanked:       false,
+        allow_prerelease:   false,
+    };
+    let result = dr.update_toml(toml).unwrap();
     assert_eq!(result, expected);
 
 }
 
-fn version_matches(local_version: &str,
-                   online_version: &str,
-                   use_semver: bool)
-                   -> Result<bool, Box<dyn error::Error>> {
-    if use_semver {
-        let local_version_sem = match VersionReq::parse(local_version) {
-            Ok(v) => Ok(v),
-            Err(e) => Err(Box::new(Error(format!("Failed to parse Cargo.toml version '{}': {}",
-                                                 local_version, e)))),
-        }?;
-        let online_version_sem = match Version::parse(online_version) {
-            Ok(v) => Ok(v),
-            Err(e) => Err(Box::new(Error(format!("Failed to parse online version '{}': {}",
-                                                 online_version, e)))),
-        }?;
-        Ok(local_version_sem.matches(&online_version_sem))
-    } else {
-        Ok(*local_version == *online_version)
+impl DepRefresh {
+    fn version_matches(&self,
+                       local_version: &str,
+                       online_version: &str)
+                       -> Result<bool, Box<dyn error::Error>> {
+        if self.use_semver {
+            let local_version_sem = match VersionReq::parse(local_version) {
+                Ok(v) => Ok(v),
+                Err(e) => Err(Box::new(Error(format!("Failed to parse Cargo.toml version '{}': {}",
+                                                     local_version, e)))),
+            }?;
+            let online_version_sem = match Version::parse(online_version) {
+                Ok(v) => Ok(v),
+                Err(e) => Err(Box::new(Error(format!("Failed to parse online version '{}': {}",
+                                                     online_version, e)))),
+            }?;
+            Ok(local_version_sem.matches(&online_version_sem))
+        } else {
+            Ok(*local_version == *online_version)
+        }
     }
-}
 
-fn check_version(updates_crate: &mut Vec<(String, String, String)>,
-                 the_crate: &str,
-                 local_version: &str,
-                 use_semver: bool)
-                 -> Result<(), Box<dyn error::Error>> {
-    let local_version = local_version.trim().to_string();
-    println!("\t\tLocal version:  {}", local_version);
+    fn check_version(&self,
+                     updates_crate: &mut Vec<(String, String, String)>,
+                     the_crate: &str,
+                     local_version: &str)
+                     -> Result<(), Box<dyn error::Error>> {
+        let local_version = local_version.trim().to_string();
+        println!("\t\tLocal version:  {}", local_version);
 
-    let online_version = lookup_latest_version(the_crate)?;
-    println!("\t\tOnline version: {}", &online_version);
+        let online_version = self.lookup_latest_version(the_crate)?;
+        println!("\t\tOnline version: {}", &online_version);
 
-    if !version_matches(&local_version, &online_version, use_semver)? {
-        updates_crate.push((the_crate.to_string(), local_version, online_version));
+        if !self.version_matches(&local_version, &online_version)? {
+            updates_crate.push((the_crate.to_string(), local_version, online_version));
+        }
+        Ok(())
     }
-    Ok(())
-}
 
-fn update_info(the_crate: &str,
-               local_version: &str,
-               online_version: &str) {
-    println!("\tUpdating: {} {} => {}",
-             the_crate,
-             local_version,
-             online_version);
-}
+    fn update_info(&self,
+                   the_crate: &str,
+                   local_version: &str,
+                   online_version: &str) {
+        println!("\tUpdating: {} {} => {}",
+                 the_crate,
+                 local_version,
+                 online_version);
+    }
 
-fn update_toml_dep_table(doc: &mut Document,
-                         table_name: &str,
-                         use_semver: bool)
-                         -> Result<(), Box<dyn error::Error>> {
-    if let Some(table) = &doc[table_name].as_table() {
-        let mut updates_crate = Vec::new();
-        let mut updates_crate_version = Vec::new();
+    fn update_toml_dep_table(&self,
+                             doc: &mut Document,
+                             table_name: &str)
+                             -> Result<(), Box<dyn error::Error>> {
+        if let Some(table) = &doc[table_name].as_table() {
+            let mut updates_crate = Vec::new();
+            let mut updates_crate_version = Vec::new();
 
-        for (the_crate, item) in table.iter() {
-            println!("\tFound: {}", the_crate);
+            for (the_crate, item) in table.iter() {
+                println!("\tFound: {}", the_crate);
 
-            if let Some(sub_table) = item.as_table() {
-                if let Some(value) = sub_table.get("version") {
-                    if let Some(local_version) = value.as_str() {
-                        check_version(&mut updates_crate_version, the_crate, local_version, use_semver)?;
-                    }
-                }
-            } else if let Some(value) = item.as_value() {
-                if let Some(local_version) = value.as_str() {
-                    check_version(&mut updates_crate, the_crate, local_version, use_semver)?;
-                }
-                else if let Some(inline_table) = value.as_inline_table() {
-                    if let Some(value) = inline_table.get("version") {
+                if let Some(sub_table) = item.as_table() {
+                    if let Some(value) = sub_table.get("version") {
                         if let Some(local_version) = value.as_str() {
-                            check_version(&mut updates_crate_version, the_crate, local_version, use_semver)?;
+                            self.check_version(&mut updates_crate_version, the_crate, local_version)?;
                         }
                     }
+                } else if let Some(value) = item.as_value() {
+                    if let Some(local_version) = value.as_str() {
+                        self.check_version(&mut updates_crate, the_crate, local_version)?;
+                    }
+                    else if let Some(inline_table) = value.as_inline_table() {
+                        if let Some(value) = inline_table.get("version") {
+                            if let Some(local_version) = value.as_str() {
+                                self.check_version(&mut updates_crate_version, the_crate, local_version)?;
+                            }
+                        }
+                    } else {
+                        println!("** Error: Can not parse {}", value);
+                    }
                 } else {
-                    println!("** Error: Can not parse {}", value);
+                    println!("** Error: Item '{:?}' is neither table nor value.", item);
                 }
-            } else {
-                println!("** Error: Item '{:?}' is neither table nor value.", item);
+            }
+
+            for (the_crate, local_version, online_version) in updates_crate {
+                self.update_info(&the_crate, &local_version, &online_version);
+                doc[table_name][&the_crate] = toml_edit::value(online_version);
+            }
+            for (the_crate, local_version, online_version) in updates_crate_version {
+                self.update_info(&the_crate, &local_version, &online_version);
+                doc[table_name][&the_crate]["version"] = toml_edit::value(online_version);
+            }
+        }
+        Ok(())
+    }
+
+    fn update_toml(&self, toml: &str) -> Result<String, Box<dyn error::Error>> {
+        let mut doc = toml.parse::<Document>()?;
+        self.update_toml_dep_table(&mut doc, "dependencies")?;
+        self.update_toml_dep_table(&mut doc, "build-dependencies")?;
+        Ok(doc.to_string())
+    }
+
+    fn lookup_latest_version(&self, crate_name: &str) -> Result<String, Box<dyn error::Error>> {
+
+        const NAME: &str = env!("CARGO_PKG_NAME");
+        const VERSION: &str = env!("CARGO_PKG_VERSION");
+        const REPO: &str = env!("CARGO_PKG_REPOSITORY");
+        let user_agent = format!("{} {} ( {} )", NAME, VERSION, REPO);
+
+        let uri = format!("https://crates.io/api/v1/crates/{}", crate_name);
+
+        let client = reqwest::blocking::Client::builder()
+            .gzip(true)
+            .build()?;
+        let http_body = client.get(&uri)
+            .header(USER_AGENT, &user_agent)
+            .send()?
+            .text()?;
+
+        let mut version = None;
+        let json_doc: Value = serde_json::from_str(&http_body)?;
+        if let Some(json_versions) = json_doc["versions"].as_array() {
+            for json_version in json_versions {
+                if let Some(yanked) = json_version["yanked"].as_bool() {
+                    if yanked && !self.allow_yanked {
+                        // Skip this yanked version.
+                        continue;
+                    }
+                }
+                match json_version["num"].as_str() {
+                    Some(version_num) => {
+                        match Version::parse(version_num) {
+                            Ok(version_num_sem) => {
+                                if version_num_sem.is_prerelease() && !self.allow_prerelease {
+                                    // Skip this pre-release.
+                                    continue;
+                                }
+                                // Found the latest usable version.
+                                version = Some(version_num_sem.to_string());
+                                // Stop the search here.
+                                break;
+                            },
+                            Err(e) => {
+                                return Err(Box::new(Error(format!(
+                                    "Crates.io json info for '{}' did not include a valid version 'num': {}",
+                                    crate_name, e))));
+                            },
+                        }
+                    },
+                    None => {
+                        return Err(Box::new(Error(format!(
+                            "Crates.io json info for '{}' did not include version 'num'",
+                            crate_name))));
+                    },
+                }
             }
         }
 
-        for (the_crate, local_version, online_version) in updates_crate {
-            update_info(&the_crate, &local_version, &online_version);
-            doc[table_name][&the_crate] = toml_edit::value(online_version);
+        match version {
+            Some(version) => Ok(version),
+            None => {
+                Err(Box::new(Error(format!(
+                    "No usable version found for '{}' on crates.io.",
+                    crate_name))))
+            }
         }
-        for (the_crate, local_version, online_version) in updates_crate_version {
-            update_info(&the_crate, &local_version, &online_version);
-            doc[table_name][&the_crate]["version"] = toml_edit::value(online_version);
-        }
     }
-    Ok(())
-}
-
-fn update_toml(toml: &str, use_semver: bool) -> Result<String, Box<dyn error::Error>> {
-    let mut doc = toml.parse::<Document>()?;
-    update_toml_dep_table(&mut doc, "dependencies", use_semver)?;
-    update_toml_dep_table(&mut doc, "build-dependencies", use_semver)?;
-    Ok(doc.to_string())
-}
-
-fn lookup_latest_version(crate_name: &str) -> Result<String, Box<dyn error::Error>> {
-
-    const NAME: &str = env!("CARGO_PKG_NAME");
-    const VERSION: &str = env!("CARGO_PKG_VERSION");
-    const REPO: &str = env!("CARGO_PKG_REPOSITORY");
-    let user_agent = format!("{} {} ( {} )", NAME, VERSION, REPO);
-
-    let uri = format!("https://crates.io/api/v1/crates/{}", crate_name);
-
-    let client = reqwest::blocking::Client::builder()
-        .gzip(true)
-        .build()?;
-    let http_body = client.get(&uri)
-        .header(USER_AGENT, &user_agent)
-        .send()?
-        .text()?;
-
-    let json_doc: Value = serde_json::from_str(&http_body)?;
-    let mut version: String = json_doc["versions"][0]["num"].to_string();
-
-    if version.starts_with('"') {
-        version = version.get(1..).unwrap().to_string();
-    }
-    if version.ends_with('"') {
-        let end = version.len() - 1;
-        version = version.get(..end).unwrap().to_string();
-    }
-
-    Ok(version)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,7 @@ impl DepRefresh {
         let mut doc = toml.parse::<Document>()?;
         self.update_toml_dep_table(&mut doc, "dependencies")?;
         self.update_toml_dep_table(&mut doc, "build-dependencies")?;
+        self.update_toml_dep_table(&mut doc, "dev-dependencies")?;
         Ok(doc.to_string())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,7 @@ impl DepRefresh {
                     Some(version_num) => {
                         match Version::parse(version_num) {
                             Ok(version_num_sem) => {
-                                if version_num_sem.is_prerelease() && !self.allow_prerelease {
+                                if !version_num_sem.pre.is_empty() && !self.allow_prerelease {
                                     // Skip this pre-release.
                                     continue;
                                 }


### PR DESCRIPTION
Add options to use pre-releases and yanked versions.
This pull also adds support for `dev-dependencies` section and also updates the `semver` package to `1.0`.

The diff is best viewed with whitespace changes suppressed.