### PR TITLE
Add support for workspace

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,6 +1,7 @@
 extern crate libdr;
 
 use std::error;
+use std::path::Path;
 
 extern crate structopt;
 use structopt::StructOpt;
@@ -38,11 +39,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let opt = Opt::from_args();
 
     for file in &opt.toml_files {
-        libdr::update_toml_file(file,
-                                opt.unsafe_file_updates,
-                                !opt.exact,
-                                opt.yanked,
-                                opt.pre_release)?;
+        let dr = libdr::DepRefresh::new(opt.unsafe_file_updates,
+                                        !opt.exact,
+                                        opt.yanked,
+                                        opt.pre_release);
+        dr.update_toml_file(&Path::new(file))?;
     }
 
     Ok(())


### PR DESCRIPTION
This pull request adds support for workspaces:
https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html

Instead of manually specifying each Cargo.toml of every sub-package, one may only specify the main workspace Cargo.toml now.
Dependency-Refresh will then recursively scan the Cargo.toml files.